### PR TITLE
更改Application名称

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        QApplication::setApplicationName("Kylin System Monitor");
+        QApplication::setApplicationName("UKui System Monitor");
         QApplication::setApplicationVersion("0.0.0.0001");
 
         QString locale = QLocale::system().name();

--- a/ukui-system-monitor.desktop
+++ b/ukui-system-monitor.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
-Name=Kylin System Monitor
+Name=UKui System Monitor
 Name[zh_CN]=系统监视器
-Name[tr_TR]=Kylin Sistem İzleyici
-GenericName=Kylin System Monitor
+Name[tr_TR]=UKui Sistem İzleyici
+GenericName=UKui System Monitor
 GenericName[zh_CN]=系统监视器
-Comment=Kylin System Monitor
+Comment=UKui System Monitor
 Comment[zh_CN]=系统监视器
-Comment[tr_TR]=Kylin Sistem İzleyici
+Comment[tr_TR]=UKui Sistem İzleyici
 Keywords=guide; 
 Exec=/usr/bin/ukui-system-monitor
 Icon=ukui-system-monitor


### PR DESCRIPTION
在任务栏解析应用名称（通过QApplication::setApplicationName设置）与 进程名的时候发现：
我们系统中部分应用的应用名称与进程名称不一致
例如系统监视器的进程名是ukui-system-monitor,应用名称是Kylin System Monitor
这样窗管、任务栏等通过窗口id获取到的该应用名称Kylin System Monitor；top等命令通过进程获取到的名称为ukui-system-monitor
这样是不是会造成歧义？（自测大部分社区应用的命名较为规范，应用名称与进程名称一致）

（ps：
麒麟天气，麒麟刻录都有类似的问题
麒麟刻录的Application名称为k3b，进程名为burner。 不清楚这样命名的原因是什么。）